### PR TITLE
Migrating to actions/checkout@v4 and actions/upload-artifact@v4

### DIFF
--- a/.github/workflows/debian-packer.yaml
+++ b/.github/workflows/debian-packer.yaml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Generate Control File
         id: control-gen
@@ -46,7 +46,7 @@ jobs:
           package_arch: 'all'
 
       - name: Upload Generated Package File
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: generated-hello-world-package
           path: "${{ steps.container.outputs.generated_package_path }}"

--- a/.github/workflows/jobs_on_release.yaml
+++ b/.github/workflows/jobs_on_release.yaml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Latest tag Applier
         uses: EndBug/latest-tag@latest

--- a/debianpacker.py
+++ b/debianpacker.py
@@ -222,7 +222,7 @@ def main(pkg_name, pkg_version, pkg_arch, pkg_file_map, input, output, github_ou
     print("Completed!")
 
     # Sets a GitHub Actions output variable
-    gh_env_file.write("{generated_package_path}={" + get_final_package_path() + "}\n")
+    gh_env_file.write("{generated_package_path}={" + get_final_package_path() + "}")
     gh_env_file.close()
 
 

--- a/debianpacker.py
+++ b/debianpacker.py
@@ -167,7 +167,7 @@ def run_package_generation():
 @click.option('-i', '--input', type=click.Path(exists=True, readable=True), default=DEFAULT_INPUT_PATH, help=HELP_IP)
 @click.option('-o', '--output', type=click.Path(exists=False, writable=True), default=DEFAULT_OUTPUT_PATH, help=HELP_OP)
 @click.option('-gho', '--github_output', type=click.Path(exists=True, writable=True), help=HELP_GHO)
-def main(pkg_name, pkg_version, pkg_arch, pkg_file_map, input, output, env_outputs):
+def main(pkg_name, pkg_version, pkg_arch, pkg_file_map, input, output, github_output):
     click.echo("Welcome to " + APP_NAME + " by " + APP_AUTHOR + "\n")
 
     # Saves the Package Variables
@@ -187,7 +187,7 @@ def main(pkg_name, pkg_version, pkg_arch, pkg_file_map, input, output, env_outpu
 
     # Opens the GitHub Environments File (replaces ::set-output)
     global gh_outputs_file_path
-    gh_outputs_file_path = env_outputs
+    gh_outputs_file_path = github_output
     gh_env_file = os.open(gh_outputs_file_path, os.O_APPEND)
 
     # Loads JSON File as a local variable

--- a/debianpacker.py
+++ b/debianpacker.py
@@ -188,7 +188,7 @@ def main(pkg_name, pkg_version, pkg_arch, pkg_file_map, input, output, github_ou
     # Opens the GitHub Environments File (replaces ::set-output)
     global gh_outputs_file_path
     gh_outputs_file_path = github_output
-    gh_env_file = open(gh_outputs_file_path, "a")
+    gh_env_file = open(gh_outputs_file_path, "w")
 
     # Loads JSON File as a local variable
     the_map = json.load(pkg_file_map)

--- a/debianpacker.py
+++ b/debianpacker.py
@@ -166,8 +166,7 @@ def run_package_generation():
 @click.option('-m', '--pkg_file_map', type=click.File('r'), default=DEFAULT_FILE_MAP, help=HELP_FILE_MAP)
 @click.option('-i', '--input', type=click.Path(exists=True, readable=True), default=DEFAULT_INPUT_PATH, help=HELP_IP)
 @click.option('-o', '--output', type=click.Path(exists=False, writable=True), default=DEFAULT_OUTPUT_PATH, help=HELP_OP)
-@click.option('-gho', '--github_output', type=click.Path(exists=True, writable=True), help=HELP_GHO)
-def main(pkg_name, pkg_version, pkg_arch, pkg_file_map, input, output, github_output):
+def main(pkg_name, pkg_version, pkg_arch, pkg_file_map, input, output):
     click.echo("Welcome to " + APP_NAME + " by " + APP_AUTHOR + "\n")
 
     # Saves the Package Variables
@@ -185,10 +184,10 @@ def main(pkg_name, pkg_version, pkg_arch, pkg_file_map, input, output, github_ou
     output_src = output
     print("Output Prefix: " + output_src + "\n")
 
-    # Opens the GitHub Environments File (replaces ::set-output)
+    # Opens the GitHub Outputs Environment File (replaces ::set-output)
     global gh_outputs_file_path
-    gh_outputs_file_path = github_output
-    gh_env_file = open(gh_outputs_file_path, "w")
+    gh_outputs_file_path = os.getenv("GITHUB_OUTPUT")
+    gh_outputs_file = open(gh_outputs_file_path, "a")
 
     # Loads JSON File as a local variable
     the_map = json.load(pkg_file_map)
@@ -222,8 +221,8 @@ def main(pkg_name, pkg_version, pkg_arch, pkg_file_map, input, output, github_ou
     print("Completed!")
 
     # Sets a GitHub Actions output variable
-    gh_env_file.write("{generated_package_path}={" + get_final_package_path() + "}")
-    gh_env_file.close()
+    gh_outputs_file.write("generated_package_path=" + get_final_package_path() + "\n")
+    gh_outputs_file.close()
 
 
 # Ensures Main Function is to be run first

--- a/debianpacker.py
+++ b/debianpacker.py
@@ -188,7 +188,7 @@ def main(pkg_name, pkg_version, pkg_arch, pkg_file_map, input, output, github_ou
     # Opens the GitHub Environments File (replaces ::set-output)
     global gh_outputs_file_path
     gh_outputs_file_path = github_output
-    gh_env_file = os.open(gh_outputs_file_path, os.O_APPEND)
+    gh_env_file = open(gh_outputs_file_path, "a")
 
     # Loads JSON File as a local variable
     the_map = json.load(pkg_file_map)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -72,12 +72,11 @@ echo "PACKAGE ARCH  = ${PKG_ARCH}"
 echo "LAYOUT MAP FILE  = ${PKG_MAP}"
 echo "INPUT DIRECTORY PATH  = ${PKG_IN_DIR}"
 echo "OUTPUT DIRECTORY PATH  = ${PKG_OUT_DIR}"
-echo "GITHUB ENVIRONMENTS PATH = $GITHUB_OUTPUT"
 
 # Runs the Main Application
 echo ""
 echo "Starting Debian Packer Application"
-DP_ARGS="-n ${PKG_NAME} -v ${PKG_VER} -a ${PKG_ARCH} -m ${PKG_MAP} -i ${PKG_IN_DIR} -o ${PKG_OUT_DIR} -gho $GITHUB_OUTPUT"
+DP_ARGS="-n ${PKG_NAME} -v ${PKG_VER} -a ${PKG_ARCH} -m ${PKG_MAP} -i ${PKG_IN_DIR} -o ${PKG_OUT_DIR}"
 if debpack ${DP_ARGS} ; then
   echo "Success"
 else

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -72,11 +72,12 @@ echo "PACKAGE ARCH  = ${PKG_ARCH}"
 echo "LAYOUT MAP FILE  = ${PKG_MAP}"
 echo "INPUT DIRECTORY PATH  = ${PKG_IN_DIR}"
 echo "OUTPUT DIRECTORY PATH  = ${PKG_OUT_DIR}"
+echo "GITHUB ENVIRONMENTS PATH = $GITHUB_OUTPUT"
 
 # Runs the Main Application
 echo ""
 echo "Starting Debian Packer Application"
-DP_ARGS="-n ${PKG_NAME} -v ${PKG_VER} -a ${PKG_ARCH} -m ${PKG_MAP} -i ${PKG_IN_DIR} -o ${PKG_OUT_DIR}"
+DP_ARGS="-n ${PKG_NAME} -v ${PKG_VER} -a ${PKG_ARCH} -m ${PKG_MAP} -i ${PKG_IN_DIR} -o ${PKG_OUT_DIR} -gho $GITHUB_OUTPUT"
 if debpack ${DP_ARGS} ; then
   echo "Success"
 else


### PR DESCRIPTION
Updated the following:

- actions/checkout@v2 to actions/checkout@v4
- actions/upload-artifact@v2 to actions/upload-artifact@v4
- Replaced usage of `::set-output` to updating the Environment file found at the `$GITHUB_OUTPUT` variable to set an output variable.