### PR TITLE
Migrating to Ubuntu 24.04

### DIFF
--- a/.github/workflows/debian-packer.yaml
+++ b/.github/workflows/debian-packer.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   deb-control-file-build:
     name: Generate Debian Package
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout

--- a/.github/workflows/jobs_on_release.yaml
+++ b/.github/workflows/jobs_on_release.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   release-job:
     name: Release Workflows
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 
 COPY entrypoint.sh /entrypoint.sh
 COPY debianpacker.py /usr/bin/debpack

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,6 @@ RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 
 # Installs Python and VENV and creates a Python Virtual Environment (venv)
-RUN apt-get update && apt-get install -y python3 python3-pip python3-venv && ln -s python3 /usr/bin/python && python3 -m venv $VIRTUAL_ENV
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"
-RUN pip3 install -r /requirements.txt
+ENV PATH="$VENV/bin:$PATH"
+RUN apt-get update && apt-get install -y python3 python3-pip python3-venv && ln -s python3 /usr/bin/python && python3 -m venv $VENV
+RUN pip install -r /requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,18 @@
 FROM ubuntu:24.04
 
+# Sets the Virtual Environment path as an environment variable
+ENV VENV=/opt/venv
+
+# Copies the required files
 COPY entrypoint.sh /entrypoint.sh
 COPY debianpacker.py /usr/bin/debpack
 COPY requirements.txt /requirements.txt
 
+# Makes the entrypoint.sh Script an executable and sets it as an Entrypoint
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 
-RUN apt-get update
-RUN apt-get install -y python3 python3-pip && ln -s python3 /usr/bin/python
+# Installs Python and VENV and creates a Python Virtual Environment (venv)
+RUN apt-get update && apt-get install -y python3 python3-pip python3-venv && ln -s python3 /usr/bin/python && python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 RUN pip3 install -r /requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,4 @@ ENTRYPOINT ["/entrypoint.sh"]
 # Installs Python and VENV and creates a Python Virtual Environment (venv)
 ENV PATH="$VENV/bin:$PATH"
 RUN apt-get update && apt-get install -y python3 python3-pip python3-venv && ln -s python3 /usr/bin/python && python3 -m venv $VENV
-RUN pip install -r /requirements.txt
+RUN pip3 install -r /requirements.txt


### PR DESCRIPTION
Migrating the Dockerfile and the GitHub Running Environments to use Ubuntu 24.04 due to Ubuntu 20.04 no longer being supported. In doing so, the Python code is now run within a Virtual Environment (VENV) within the Docker Container.